### PR TITLE
RuboCop fixes: Documentation strings

### DIFF
--- a/lib/bundler/ecology.rb
+++ b/lib/bundler/ecology.rb
@@ -4,6 +4,7 @@ require 'bundler/ecology/handlers/before_install'
 require 'bundler/ecology/version'
 
 module Bundler
+  # Bundler plugin to blacklist gems from lockfiles.
   module Ecology
     def self.register
       before_install_handler = Handlers::BeforeInstall.new(config)

--- a/lib/bundler/ecology/handlers/before_install.rb
+++ b/lib/bundler/ecology/handlers/before_install.rb
@@ -5,6 +5,7 @@ require 'yaml'
 module Bundler
   module Ecology
     module Handlers
+      # Bundle plugin handler used with the 'before-install' hook.
       class BeforeInstall
         def initialize(config)
           @gem_names = config.fetch(:disallowed, []).map { |item| item[:name] }

--- a/lib/bundler/ecology/version.rb
+++ b/lib/bundler/ecology/version.rb
@@ -2,6 +2,6 @@
 
 module Bundler
   module Ecology
-    VERSION = '0.1.1'
+    VERSION = '0.1.1'.freeze
   end
 end


### PR DESCRIPTION
This PR made RuboCop stop outputting warnings on my machine.