### PR TITLE
README: Add tagline to top of document

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 # Bundler::Ecology
 
+Bundler plugin to blacklist gems from lockfiles.
+
 ## Installation
 
 Add this line to your Gemfile:


### PR DESCRIPTION
This PR adds the comment from the plugin file to the start of the README.

This would help passers-by to understand what good this plugin is.

(This is a redundancy, for clarity.)