### PR TITLE
CI: Remove specific version of Bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ cache: bundler
 rvm:
   - 2.5.7
 
-before_install: gem install bundler -v 1.17.3
-
 deploy:
   provider: rubygems
   api_key:


### PR DESCRIPTION
This PR attempts to improve the CI configuration by removing the specific version 1.17.3, so that the version that ships with Ruby and RubyGems becomes the one we run the tests with.

If this works, the benefit is that the CI configuration is easier to understand.

If it does not work, we have learned things we can document in the README as "known limitations".